### PR TITLE
Allow data from gulp-data

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = (opts) => {
 		filters: {},
 		tags: {},
 		plugins: [],
-		data: {},
+		data: {}
 	}
 
 	const options = objectAssignDeep(defaults, opts)

--- a/index.js
+++ b/index.js
@@ -42,6 +42,10 @@ module.exports = (opts) => {
 	return through.obj((file, encoding, callback) => {
 		const f = file
 
+		if (f.data) {
+			objectAssignDeep(options.data, f.data);
+		}
+
 		if (f.isNull()) {
 			return callback(null, f)
 		}

--- a/index.js
+++ b/index.js
@@ -40,10 +40,10 @@ module.exports = (opts) => {
 	}
 
 	return through.obj((file, encoding, callback) => {
-		const f = file
+		const f = file;
 
 		if (f.data) {
-			objectAssignDeep(options.data, f.data)
+			options.data = f.data;
 		}
 
 		if (f.isNull()) {

--- a/index.js
+++ b/index.js
@@ -40,10 +40,10 @@ module.exports = (opts) => {
 	}
 
 	return through.obj((file, encoding, callback) => {
-		const f = file;
+		const f = file
 
 		if (f.data) {
-			options.data = f.data;
+			options.data = f.data
 		}
 
 		if (f.isNull()) {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = (opts) => {
 		filters: {},
 		tags: {},
 		plugins: [],
-		data: {}
+		data: {},
 	}
 
 	const options = objectAssignDeep(defaults, opts)
@@ -43,7 +43,7 @@ module.exports = (opts) => {
 		const f = file
 
 		if (f.data) {
-			objectAssignDeep(options.data, f.data);
+			objectAssignDeep(options.data, f.data)
 		}
 
 		if (f.isNull()) {


### PR DESCRIPTION
I have updated the plugin to receive be compatible with latest version of gulp-data. According to https://github.com/colynb/gulp-data#note-to-gulp-plugin-authors plugins should also listen for `file.data` besides `opts.data`.